### PR TITLE
Switch link-visited-color and link-color

### DIFF
--- a/lib/extras/hn_theme_dark.styl
+++ b/lib/extras/hn_theme_dark.styl
@@ -1,8 +1,8 @@
 // Colors
 base-color = #cc6633
 text-color = #a59f85
-link-color = darken(base-color, 20%)
-link-visited-color = lighten(base-color, 20%)
+link-color = lighten(base-color, 20%)
+link-visited-color = darken(base-color, 20%)
 page-background-color = #222222
 light-link-color = #fbf9f7
 text-button-color = #a59f85


### PR DESCRIPTION
Hi Daniel! Excellent fork, I'm enjoying it a lot!

It is my understanding that from an accessibility point of view, **visited links** should melt a bit with its background as a visual indicator to the user that he's already been there.

Following that logic, the **exact opposite** is expected for dark themes, therefore visited links should be lighter that regular ones.